### PR TITLE
chore: remove unnecessary nixpacks

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,2 +1,0 @@
-[phases.setup]
-providers = ["...", "python"]


### PR DESCRIPTION
- Remove nixpacks.toml which is no longer needed