### PR TITLE
chore: updated web components versions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID="your-project-id"
 NEXT_PUBLIC_SUPPORT_EMAIL="test@test.com"
 NEXT_PUBLIC_APP_URL="www.example.com"
+NEXT_PUBLIC_RPC_URL_ETHEREUM=https://eth.llamarpc.com
+NEXT_PUBLIC_RPC_URL_POLYGON=https://1rpc.io/matic
+NEXT_PUBLIC_RPC_URL_SEPOLIA=https://sepolia.drpc.org

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "request-network-template",
       "version": "0.1.0",
       "dependencies": {
-        "@requestnetwork/create-invoice-form": "^0.2.0",
-        "@requestnetwork/invoice-dashboard": "^0.3.0",
+        "@requestnetwork/create-invoice-form": "^0.3.0",
+        "@requestnetwork/invoice-dashboard": "^0.3.1",
         "@requestnetwork/request-client.js": "0.45.0",
         "@requestnetwork/shared": "^0.3.0",
         "@requestnetwork/web3-signature": "0.5.0",
@@ -5461,26 +5461,18 @@
       }
     },
     "node_modules/@requestnetwork/create-invoice-form": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@requestnetwork/create-invoice-form/-/create-invoice-form-0.2.0.tgz",
-      "integrity": "sha512-sOgTv7iCicxW1U1sSWNNh+O3ju496Tx5ZT5nlRNNXM7XLaR82PCecnbbJ4r6ymrSd4VU2KGJchJQCqVYdBmdnA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@requestnetwork/create-invoice-form/-/create-invoice-form-0.3.0.tgz",
+      "integrity": "sha512-KDoi7eOsosUHh61sOuCzhvf/KZeXckL3CE+hw6a1yWqiF5H7TJ44GVHd1Zu6l9Ca4cx2oCTBgTlm56hsdEEBHw==",
       "dependencies": {
         "@requestnetwork/request-client.js": "0.45.0",
-        "@requestnetwork/shared": "0.2.0",
+        "@requestnetwork/shared": "0.3.0",
         "@requestnetwork/web3-signature": "0.5.0",
         "browserify-zlib": "^0.2.0",
         "crypto-browserify": "^3.12.0",
         "stream-browserify": "^3.0.0",
         "svelte": "^4.0.5",
         "viem": "^2.9.15"
-      }
-    },
-    "node_modules/@requestnetwork/create-invoice-form/node_modules/@requestnetwork/shared": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@requestnetwork/shared/-/shared-0.2.0.tgz",
-      "integrity": "sha512-zr87KvuI+YlpOCEwvnCxezqlFsRNlVrDxPj6wscEev/ENqMl+tHrqwkroP18R5L6y5r53+0G7VY9nqqv3m5nBQ==",
-      "dependencies": {
-        "svelte": "^4.0.0"
       }
     },
     "node_modules/@requestnetwork/currency": {
@@ -6207,14 +6199,14 @@
       }
     },
     "node_modules/@requestnetwork/invoice-dashboard": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@requestnetwork/invoice-dashboard/-/invoice-dashboard-0.3.0.tgz",
-      "integrity": "sha512-0eleDaUPz6d7ohcC4IhyetzT8aWrQrwnZgA76kSSFe4YOrTZfM/ywlOrB85N7/F7uHvoTKiVH0mjuw2T0rJXgA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@requestnetwork/invoice-dashboard/-/invoice-dashboard-0.3.1.tgz",
+      "integrity": "sha512-EH4rnXgYMJ1LnDnpqaQlXONX5xxyu/fJpg2+VG/0r5/8xoXT+b1fn4qydYvPRhuX8Ax2FtmqnkwVqkudNAo4Ng==",
       "dependencies": {
         "@requestnetwork/payment-detection": "0.42.0",
         "@requestnetwork/payment-processor": "0.44.0",
         "@requestnetwork/request-client.js": "0.45.0",
-        "@requestnetwork/shared": "^0.2.0",
+        "@requestnetwork/shared": "^0.3.0",
         "@requestnetwork/web3-signature": "0.5.0",
         "@web3-onboard/core": "^2.21.6",
         "browserify-zlib": "^0.2.0",
@@ -6861,14 +6853,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@requestnetwork/invoice-dashboard/node_modules/@requestnetwork/shared": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@requestnetwork/shared/-/shared-0.2.0.tgz",
-      "integrity": "sha512-zr87KvuI+YlpOCEwvnCxezqlFsRNlVrDxPj6wscEev/ENqMl+tHrqwkroP18R5L6y5r53+0G7VY9nqqv3m5nBQ==",
-      "dependencies": {
-        "svelte": "^4.0.0"
       }
     },
     "node_modules/@requestnetwork/invoice-dashboard/node_modules/@requestnetwork/smart-contracts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "request-network-template",
       "version": "0.1.0",
       "dependencies": {
-        "@requestnetwork/create-invoice-form": "^0.3.0",
-        "@requestnetwork/invoice-dashboard": "^0.3.1",
+        "@requestnetwork/create-invoice-form": "^0.4.0",
+        "@requestnetwork/invoice-dashboard": "^0.4.0",
         "@requestnetwork/request-client.js": "0.45.0",
-        "@requestnetwork/shared": "^0.3.0",
+        "@requestnetwork/shared": "^0.4.0",
         "@requestnetwork/web3-signature": "0.5.0",
         "@web3-onboard/coinbase": "^2.2.7",
         "@web3-onboard/core": "^2.21.6",
@@ -5461,12 +5461,12 @@
       }
     },
     "node_modules/@requestnetwork/create-invoice-form": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@requestnetwork/create-invoice-form/-/create-invoice-form-0.3.0.tgz",
-      "integrity": "sha512-KDoi7eOsosUHh61sOuCzhvf/KZeXckL3CE+hw6a1yWqiF5H7TJ44GVHd1Zu6l9Ca4cx2oCTBgTlm56hsdEEBHw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@requestnetwork/create-invoice-form/-/create-invoice-form-0.4.0.tgz",
+      "integrity": "sha512-1Uk+HLDf6FNYbyRyrI5I3oGu490xJAbyl1ukE4npCvWmryAtTK/jukii6h0hohqeO5b1PoAQ2yl44PDmI4zPVA==",
       "dependencies": {
         "@requestnetwork/request-client.js": "0.45.0",
-        "@requestnetwork/shared": "0.3.0",
+        "@requestnetwork/shared": "0.4.0",
         "@requestnetwork/web3-signature": "0.5.0",
         "browserify-zlib": "^0.2.0",
         "crypto-browserify": "^3.12.0",
@@ -6199,14 +6199,14 @@
       }
     },
     "node_modules/@requestnetwork/invoice-dashboard": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@requestnetwork/invoice-dashboard/-/invoice-dashboard-0.3.1.tgz",
-      "integrity": "sha512-EH4rnXgYMJ1LnDnpqaQlXONX5xxyu/fJpg2+VG/0r5/8xoXT+b1fn4qydYvPRhuX8Ax2FtmqnkwVqkudNAo4Ng==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@requestnetwork/invoice-dashboard/-/invoice-dashboard-0.4.0.tgz",
+      "integrity": "sha512-FjKIcP+2CClxqufHUc4h/iUuM3opT93nNe+BKMSmTWiFy2bqvlzsKLqms+CFHOIq7uVXo95xTn4s9HYg4R8wAw==",
       "dependencies": {
         "@requestnetwork/payment-detection": "0.42.0",
         "@requestnetwork/payment-processor": "0.44.0",
         "@requestnetwork/request-client.js": "0.45.0",
-        "@requestnetwork/shared": "^0.3.0",
+        "@requestnetwork/shared": "^0.4.0",
         "@requestnetwork/web3-signature": "0.5.0",
         "@web3-onboard/core": "^2.21.6",
         "browserify-zlib": "^0.2.0",
@@ -9126,9 +9126,9 @@
       }
     },
     "node_modules/@requestnetwork/shared": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@requestnetwork/shared/-/shared-0.3.0.tgz",
-      "integrity": "sha512-dQ284IWVmz69BtQa/Vx65jTNSxISafZWDji68p/g8jVm54yv42Y2+HBqc8KHWr8DFQ3DYt/74QPHpxxme+/nlQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@requestnetwork/shared/-/shared-0.4.0.tgz",
+      "integrity": "sha512-xTWgisdmPPSD31umHB6EpBZm+EIDDQfR/MoY3Gyz4xR/QVs4vHmlUuLjP6prB8elOV8rwfeyJ+Magv/DOoWz6w==",
       "dependencies": {
         "svelte": "^4.0.0",
         "viem": "^2.13.1"

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@requestnetwork/create-invoice-form": "^0.2.0",
-    "@requestnetwork/invoice-dashboard": "^0.3.0",
+    "@requestnetwork/create-invoice-form": "^0.3.0",
+    "@requestnetwork/invoice-dashboard": "^0.3.1",
     "@requestnetwork/request-client.js": "0.45.0",
     "@requestnetwork/shared": "^0.3.0",
     "@requestnetwork/web3-signature": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@requestnetwork/create-invoice-form": "^0.3.0",
-    "@requestnetwork/invoice-dashboard": "^0.3.1",
+    "@requestnetwork/create-invoice-form": "^0.4.0",
+    "@requestnetwork/invoice-dashboard": "^0.4.0",
     "@requestnetwork/request-client.js": "0.45.0",
-    "@requestnetwork/shared": "^0.3.0",
+    "@requestnetwork/shared": "^0.4.0",
     "@requestnetwork/web3-signature": "0.5.0",
     "@web3-onboard/coinbase": "^2.2.7",
     "@web3-onboard/core": "^2.21.6",


### PR DESCRIPTION
- updated to latest package versions (again)
- updated env.example - Add `NEXT_PUBLIC_RPC_URL_` for Ethereum, Polygon, and Sepolia