### PR TITLE
chore: describe deployment process in README, rename deployment workflows

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -1,4 +1,4 @@
-name: cd
+name: Deploy to production
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -1,4 +1,4 @@
-name: ci
+name: Deploy to staging
 
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ npm run dev
 
 ## Deploy
 
-- [ci.yml](/.github/workflows/ci.yml) - Deploy to Staging on push to `main` branch.
-- [cd.yml](/.github/workflows/cd.yml) - Deploy to Production on release published in Github.
+We deploy to an [EasyPanel](https://easypanel.io/) server using Github Actions and [Heroku Buildpacks](https://devcenter.heroku.com/articles/buildpacks). You could easily deploy to Vercel, Netlify, or any other platform.
+
+- [deploy-to-staging.yml](/.github/workflows/deploy-to-staging.yml) - Deploy to Staging on push to `main` branch.
+- [deploy-to-production.yml](/.github/workflows/deploy-to-production.yml) - Deploy to Production on release published in Github.
 
 ## Configuration
 


### PR DESCRIPTION
# Problem

The README doesn't explain the deployment process well.

# Changes

- Rename ci and cd workflows to be more descriptive
- Update README with details about deployment and new workflow names