### PR TITLE
feat: add version badge to app

### DIFF
--- a/components/common/VersionBadge.tsx
+++ b/components/common/VersionBadge.tsx
@@ -1,0 +1,22 @@
+import { Badge } from "@/components/ui/badge";
+import Link from "next/link";
+
+interface VersionDisplayProps {
+  version: string;
+  githubRelease: string;
+}
+
+export default function VersionDisplay({
+  version,
+  githubRelease,
+}: VersionDisplayProps) {
+  return (
+    <div className="flex m-4 md:m-0 md:fixed md:bottom-4 md:left-4 md:z-10">
+      <Link href={githubRelease}>
+        <Badge variant="outline" className="text-xs font-mono">
+          {version}
+        </Badge>
+      </Link>
+    </div>
+  );
+}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-	reactStrictMode: true,
-	swcMinify: false,
+  reactStrictMode: true,
 };
 
 export default nextConfig;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,6 +6,7 @@ import { init, Web3OnboardProvider } from "@web3-onboard/react";
 import type { AppProps } from "next/app";
 import { Montserrat } from "next/font/google";
 import { onboardConfig } from "../utils/connectWallet";
+import VersionDisplay from "@/components/common/VersionBadge";
 
 const montserrat = Montserrat({ subsets: ["latin"] });
 
@@ -23,6 +24,10 @@ export default function App({ Component, pageProps }: AppProps) {
         <Provider>
           <Navbar />
           <Component {...pageProps} />
+          <VersionDisplay
+            version={process.env.NEXT_PUBLIC_VERSION as string}
+            githubRelease={process.env.NEXT_PUBLIC_GITHUB_RELEASE as string}
+          />
         </Provider>
       </Web3OnboardProvider>
       <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GTM_ID as string} />


### PR DESCRIPTION
Resolves #59 

- Add version badge component that displays current template version and link to github releases page.


![image](https://github.com/user-attachments/assets/07f216e7-cc8a-46ce-b84e-83a8810e6570)
