### PR TITLE
fix: specify node version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,9 @@
         "postcss": "^8",
         "tailwindcss": "^3.4.3",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": "18.x"
       }
     },
     "node_modules/@adraffy/ens-normalize": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "start": "next start",
     "lint": "next lint"
   },
+  "engines": {
+    "node": "18.x"
+  },
   "dependencies": {
     "@next/third-parties": "^15.0.3",
     "@radix-ui/react-dialog": "^1.1.0",


### PR DESCRIPTION
## Problem

It is not building on heroku buildpacks 

## Change
Specify node version for build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Specified the required Node.js version (18.x) for the application in the project configuration.

- **Chores**
	- Updated project configuration to enhance compatibility and deployment clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->