### PR TITLE
fix: add several fiat currencies

### DIFF
--- a/utils/currencies.ts
+++ b/utils/currencies.ts
@@ -1,6 +1,33 @@
 import { RequestLogicTypes, CurrencyTypes } from "@requestnetwork/types";
 
 export const createFormCurrencies: CurrencyTypes.CurrencyInput[] = [
+  // Fiat
+  {
+    symbol: "USD",
+    decimals: 2,
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+  },
+  {
+    symbol: "EUR",
+    decimals: 2,
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+  },
+  {
+    symbol: "GBP",
+    decimals: 2,
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+  },
+  {
+    symbol: "JPY",
+    decimals: 0,
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+  },
+  {
+    symbol: "CNY",
+    decimals: 2,
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+  },
+
   // Sepolia Testnet
   {
     symbol: "FAU",


### PR DESCRIPTION
# Problem

Fiat currencies accidentally removed in #99 

[Screencast from 2024-12-20 17-03-50.webm](https://github.com/user-attachments/assets/4dc068e6-75a9-4320-9e47-19091719d212)

# Changes

* Add USD, EUR, GBP, JPY, and CNY fiat currencies to create request form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added five new fiat currencies (USD, EUR, GBP, JPY, CNY) to the currency selection.
	- Expanded the range of currencies available for use in forms, enhancing user options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->