### PR TITLE
fix: update currency address to prevent mismatch and add fiat.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     paths:
-      - '**/*.{js,jsx,ts,tsx}'
-      - 'package*.json'
-      - '.github/workflows/build.yml'
-      - 'nixpacks.toml'
+      - "**/*.{js,jsx,ts,tsx}"
+      - "package*.json"
+      - ".github/workflows/build.yml"
+      - "nixpacks.toml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,21 +17,27 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container:
       image: node:18
-      options: --memory=4g
+      options: --memory=6g
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
-          cache: 'npm'
+          node-version: "18"
+          cache: "npm"
 
       - name: Install dependencies
-        run: npm install --omit=optional
+        run: |
+          npm clean-install --omit=optional
+          npm cache verify
+        continue-on-error: false
 
       - name: Build
         run: |
@@ -39,7 +45,8 @@ jobs:
           npm run build
         env:
           NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID }}
-          NODE_OPTIONS: "--max_old_space_size=4096 --no-warnings"
+          NODE_OPTIONS: "--max_old_space_size=6144 --no-warnings"
           NEXT_TELEMETRY_DISABLED: "1"
           NPM_CONFIG_PRODUCTION: "false"
           NODE_ENV: "production"
+        timeout-minutes: 10

--- a/utils/currencies.ts
+++ b/utils/currencies.ts
@@ -1,6 +1,84 @@
 import { RequestLogicTypes, CurrencyTypes } from "@requestnetwork/types";
 
 export const createFormCurrencies: CurrencyTypes.CurrencyInput[] = [
+  // FIAT
+  {
+    decimals: 2,
+    symbol: "USD",
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+  },
+  {
+    decimals: 2,
+    symbol: "EUR",
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+  },
+  {
+    decimals: 2,
+    symbol: "AUD",
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+  },
+  {
+    decimals: 2,
+    symbol: "BRL",
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+  },
+  {
+    decimals: 2,
+    symbol: "CAD",
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+  },
+  {
+    decimals: 2,
+    symbol: "CHF",
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+  },
+  {
+    decimals: 2,
+    symbol: "CNY",
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+  },
+
+  {
+    decimals: 2,
+    symbol: "GBP",
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+  },
+  {
+    decimals: 2,
+    symbol: "IDR",
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+  },
+  {
+    decimals: 2,
+    symbol: "INR",
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+  },
+  {
+    decimals: 0,
+    symbol: "JPY",
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+  },
+  {
+    decimals: 0,
+    symbol: "KRW",
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+  },
+  {
+    decimals: 2,
+    symbol: "NZD",
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+  },
+  {
+    decimals: 2,
+    symbol: "SGD",
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+  },
+  {
+    decimals: 2,
+    symbol: "TRY",
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+  },
+
   // Sepolia Testnet
   {
     symbol: "FAU",
@@ -11,14 +89,14 @@ export const createFormCurrencies: CurrencyTypes.CurrencyInput[] = [
   },
   {
     symbol: "fUSDT",
-    address: "0x7169D38820dfd117C3FA1f22a697dBA58d90BA06",
+    address: "0xF046b3CA5ae2879c6bAcC4D42fAF363eE8379F78",
     network: "sepolia",
     decimals: 6,
     type: RequestLogicTypes.CURRENCY.ERC20,
   },
   {
     symbol: "fUSDC",
-    address: "0x8267cF9254734C6Eb452a7bb9AAF97B392258b21",
+    address: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
     network: "sepolia",
     decimals: 6,
     type: RequestLogicTypes.CURRENCY.ERC20,


### PR DESCRIPTION
- Update address to `fUSDC` and `fUSDT` to prevent a mismatch between `create-invoice-form` and `invoice-dashboard.`
- Add fiat currencies to the list to enable conversion again.

#### Note:
- This works more as a hotfix since demos cannot proceed with the `unknown currency issue`. It would be worth checking a way to make sure both web components ingest the same list of currencies automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for multiple international fiat currencies (USD, EUR, AUD, BRL, CAD, CHF, CNY, GBP, IDR, INR, JPY, KRW, NZD, SGD, TRY)

- **Improvements**
	- Updated addresses for fUSDT and fUSDC tokens
	- Enhanced currency support with precise decimal handling for different currency types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->