### PR TITLE
chore: create-invoice-form 0.13.0, remove broken conversion currencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@next/third-parties": "^15.1.0",
         "@radix-ui/react-dialog": "^1.1.0",
         "@rainbow-me/rainbowkit": "^2.2.1",
-        "@requestnetwork/create-invoice-form": "0.12.4",
+        "@requestnetwork/create-invoice-form": "0.13.0",
         "@requestnetwork/invoice-dashboard": "0.15.2",
         "@requestnetwork/lit-protocol-cipher": "0.9.0",
         "@requestnetwork/payment-detection": "0.53.0",
@@ -4134,9 +4134,9 @@
       }
     },
     "node_modules/@requestnetwork/create-invoice-form": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/@requestnetwork/create-invoice-form/-/create-invoice-form-0.12.4.tgz",
-      "integrity": "sha512-pjWOOrSEqkIGr4URbLaWwgHEHy5GjFYz6ICfHP/Lki/hqyDrBRDUCPh6CWox0PCHStjJu6PL78WuBE9FFQycDQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@requestnetwork/create-invoice-form/-/create-invoice-form-0.13.0.tgz",
+      "integrity": "sha512-VmypNW/TgqaI0fb8zoQEkEhZZS/6rWTCGwNNrShSlmmO/YtHm24gRWFLdQL/E+dBN2cjTdwBwvpMMDqdLOvSgQ==",
       "dependencies": {
         "@requestnetwork/data-format": "0.19.9",
         "@requestnetwork/request-client.js": "0.58.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@next/third-parties": "^15.1.0",
     "@radix-ui/react-dialog": "^1.1.0",
     "@rainbow-me/rainbowkit": "^2.2.1",
-    "@requestnetwork/create-invoice-form": "0.12.4",
+    "@requestnetwork/create-invoice-form": "0.13.0",
     "@requestnetwork/invoice-dashboard": "0.15.2",
     "@requestnetwork/lit-protocol-cipher": "0.9.0",
     "@requestnetwork/payment-detection": "0.53.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "request-network-template",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
# Problem 

https://github.com/RequestNetwork/web-components/issues/316

# Bandaid Solution

Temporarily remove the failing currencies.

# Changes

* chore: update create-invoice-form to remove broken conversion currencies
* chore: update version number to 0.13.0 from 0.12.0 

# Related 
https://github.com/RequestNetwork/web-components/pull/338

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the package version to 0.13.0.
  - Upgraded the invoice form dependency to version 0.13.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->