### PR TITLE
fix: increase max-old-space-size to 15 GiB

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,6 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    container:
-      image: node:18
-      options: --memory=8g
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,12 +37,8 @@ jobs:
 
       - name: Build
         run: |
-          ulimit -S -c unlimited
           npm run build
         env:
           NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID }}
           NODE_OPTIONS: "--max_old_space_size=7680"
-          NEXT_TELEMETRY_DISABLED: "1"
-          NPM_CONFIG_PRODUCTION: "false"
           NODE_ENV: "production"
-        timeout-minutes: 10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,5 +40,9 @@ jobs:
           npm run build
         env:
           NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID }}
-          NODE_OPTIONS: "--max_old_space_size=7680"
           NODE_ENV: "production"
+
+          # Set --max_old_space_size to 15 GiB
+          # Default is 16 GiB. Leave 1 GiB for the system.
+          # Ref: https://docs.github.com/en/enterprise-cloud@latest/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+          NODE_OPTIONS: "--max-old-space-size=15360"

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -21,8 +21,6 @@ cmd = 'npm start'
 [variables]
 NODE_ENV = 'production'
 NODE_OPTIONS = '--max_old_space_size=2048'
-NPM_CONFIG_PRODUCTION = 'false'
-NEXT_TELEMETRY_DISABLED = '1'
 
 [nixpacks]
 start-command = 'npm start'

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -20,7 +20,7 @@ cmd = 'npm start'
 
 [variables]
 NODE_ENV = 'production'
-NODE_OPTIONS = '--max_old_space_size=2048'
+NODE_OPTIONS = '--max-old-space-size=2048'
 
 [nixpacks]
 start-command = 'npm start'


### PR DESCRIPTION
# 💥 Problem

The `build` workflow silently fails - the workflow fails to start, results are never returned, and merging new changes to `main` branch is blocked.

# 🔍 Analysis

We believe that the default [`max-old-space-size`](https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-mib) is set too low by default and that building requires more memory. We've had success increasing the `max-old-space-size` in the past.

# 🚧 Changes

* Remove unused config variables. These were causing confusion about which fix was actually working and which ones were irrelevant.
  * This includes the `timeout-minutes` which was set to 15 and 10 in different places. [Default `timeout-minutes` is 360](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes)
* Rename the `max_old_space_size` to `max-old-space-size` (notice the `_` and `-`)
* Increase the `max-old-space-size` to 15 GiB. The [`ubuntu-latest` Github-hosted runner has 16 GB of memory on public repos](https://docs.github.com/en/enterprise-cloud@latest/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories).

# 📖 Reference

* [Node `max-old-space-size` docs](https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-mib)
* [How do I determine the correct "max-old-space-size" for Node.js?](https://stackoverflow.com/a/63495296)
* [Github `timeout-minutes` docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes)
* [Standard Github-hosted runner specifications](https://docs.github.com/en/enterprise-cloud@latest/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
