### PR TITLE
chore: upgrate nextJS version to avoid vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "clsx": "^2.1.1",
         "ethers": "^5.7.2",
         "lucide-react": "^0.395.0",
-        "next": "15.1.9",
+        "next": "15.1.11",
         "react": "^18",
         "react-dom": "^18",
         "tailwind-merge": "^2.3.0",
@@ -3176,9 +3176,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.1.9",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.1.9.tgz",
-      "integrity": "sha512-Te1wbiJ//I40T7UePOUG8QBwh+VVMCc0OTuqesOcD3849TVOVOyX4Hdrkx7wcpLpy/LOABIcGyLX5P/SzzXhFA==",
+      "version": "15.1.11",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.1.11.tgz",
+      "integrity": "sha512-yp++FVldfLglEG5LoS2rXhGypPyoSOyY0kxZQJ2vnlYJeP8o318t5DrDu5Tqzr03qAhDWllAID/kOCsXNLcwKw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -11478,12 +11478,12 @@
       }
     },
     "node_modules/next": {
-      "version": "15.1.9",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.1.9.tgz",
-      "integrity": "sha512-OoQpDPV2i3o5Hnn46nz2x6fzdFxFO+JsU4ZES12z65/feMjPHKKHLDVQ2NuEvTaXTRisix/G5+6hyTkwK329kA==",
+      "version": "15.1.11",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.1.11.tgz",
+      "integrity": "sha512-UiVJaOGhKST58AadwbFUZThlNBmYhKqaCs8bVtm4plTxsgKq0mJ0zTsp7t7j/rzsbAEj9WcAMdZCztjByi4EoQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.1.9",
+        "@next/env": "15.1.11",
         "@swc/counter": "0.1.3",
         "@swc/helpers": "0.5.15",
         "busboy": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "clsx": "^2.1.1",
     "ethers": "^5.7.2",
     "lucide-react": "^0.395.0",
-    "next": "15.1.9",
+    "next": "15.1.11",
     "react": "^18",
     "react-dom": "^18",
     "tailwind-merge": "^2.3.0",


### PR DESCRIPTION
### TL;DR

Upgraded Next.js from version 15.1.9 to 15.1.11.

### What changed?

This PR updates the Next.js dependency from version 15.1.9 to 15.1.11 in both package.json and package-lock.json files. The corresponding @next/env package was also updated to match the new version.

### How to test?

1. Pull the changes and run `npm install`
2. Start the development server with `npm run dev`
3. Verify that the application runs correctly with no regressions
4. Check that any Next.js specific features continue to work as expected

### Why make this change?

Keeping Next.js up to date ensures we have the latest bug fixes, security patches, and performance improvements. Version 15.1.11 likely contains important fixes that will improve the stability and security of our application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Next.js to the latest patch version for improved stability and performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->