### PR TITLE
chore: update CTA from book a demo to get in touch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,7 @@ NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID="your-project-id"
 # NEXT_PUBLIC_PAYMENTS_SUBGRAPH_URL_ZKSYNCERA=https://subgraph.satsuma-prod.com/e2e4905ab7c8/request-network--434873/request-payments-zksyncera/api
 
 # NEXT_PUBLIC_GTM_ID=GTM-XXXXXXXX
+NEXT_PUBLIC_DEMO_URL="https://2deywy.share-eu1.hsforms.com/2b92phs9LR_eJdeZoxzmoMA?utm_source=request.network&utm_medium=invoicing-template&utm_campaign=evergreen&utm_content=get_in_touch"
 
 # NEXT_PUBLIC_REQUEST_NODE=https://sepolia.gateway.request.network
 # NEXT_PUBLIC_LIT_PROTOCOL_CHAIN=ethereum

--- a/components/common/Navbar.tsx
+++ b/components/common/Navbar.tsx
@@ -84,7 +84,7 @@ const Navbar = () => {
         </a>
         <ConnectButton />
         <Button
-          text="Book a demo"
+          text="Get in touch"
           href={process.env.NEXT_PUBLIC_DEMO_URL}
           anchorProps={{ target: "_blank", rel: "noreferrer noopener" }}
         />
@@ -129,7 +129,7 @@ const Navbar = () => {
             </li>
             <li>
               <Button
-                text="Book a demo"
+                text="Get in touch"
                 href={process.env.NEXT_PUBLIC_DEMO_URL}
               />
             </li>


### PR DESCRIPTION
Fixes RequestNetwork/public-issues#67

## Problem

The current CTA uses "Book a demo" language. Marketing wants to update to "Get in touch" with a new HubSpot form URL that includes UTM tracking.

## Proposed Solution

- Update Navbar.tsx to change "Book a demo" → "Get in touch" (both desktop and mobile views)
- Add `NEXT_PUBLIC_DEMO_URL` to .env.example with the new HubSpot URL

## Considerations

- UTM parameters: `utm_source=request.network&utm_medium=invoicing-template&utm_campaign=evergreen&utm_content=get_in_touch`
- The env var change will need to be deployed to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)